### PR TITLE
feat: add tap control with events and reports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -472,15 +472,22 @@
                 }
                 
                 html += `
-                    <div class="metric ${metric.size || ''}">
+                    <div class="metric ${metric.size || ''}" data-id="${metric.id}">
                         <h3>${metric.name}</h3>
                         <div class="value">${valueDisplay}</div>
                         ${detailsHTML}
                     </div>
                 `;
             });
-            
+
             dashboard.innerHTML = html;
+
+            const tapTile = dashboard.querySelector('[data-id="tapStatus"]');
+            if (tapTile) {
+                tapTile.addEventListener('click', () => {
+                    window.location.href = '/taps.html';
+                });
+            }
         }
 
         // Функция изменения периода

--- a/public/taps-report.html
+++ b/public/taps-report.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<title>Отчёт по кранам</title>
+<style>
+body {font-family:sans-serif; margin:0; padding:1rem;}
+header {margin-bottom:1rem;}
+table {border-collapse:collapse; width:100%; margin-top:1rem;}
+th,td {border:1px solid #ccc; padding:0.5rem; text-align:center;}
+</style>
+</head>
+<body>
+<header>
+  <a href="/taps.html">← Назад</a>
+</header>
+<h1>Отчёт по кранам</h1>
+<input type="week" id="weekPicker">
+<button id="loadBtn">Загрузить</button>
+<div id="report"></div>
+<div id="events"></div>
+<script>
+function weekRange(value){
+  const [y,w]=value.split('-W').map(Number);
+  const simple=new Date(y,0,1+(w-1)*7);
+  const dow=simple.getDay();
+  const start=new Date(simple);
+  if(dow<=4) start.setDate(simple.getDate()-simple.getDay()+1);
+  else start.setDate(simple.getDate()+8-simple.getDay());
+  const end=new Date(start);
+  end.setDate(start.getDate()+7);
+  return {start,end};
+}
+function load(){
+  const val=document.getElementById('weekPicker').value;
+  if(!val) return;
+  const {start,end}=weekRange(val);
+  fetch(`/api/taps/history?start=${start.toISOString()}&end=${end.toISOString()}`)
+    .then(r=>r.json()).then(data=>{
+      const rep=document.getElementById('report');
+      let html='<table><tr><th>Кран</th><th>ACTIVE %</th><th>STOP %</th></tr>';
+      Object.entries(data.report).forEach(([tap,v])=>{
+        html+=`<tr><td>${tap}</td><td>${v.active.toFixed(1)}</td><td>${v.stop.toFixed(1)}</td></tr>`;
+      });
+      html+='</table>';
+      rep.innerHTML=html;
+      const evDiv=document.getElementById('events');
+      let evHTML='';
+      Object.entries(data.events).forEach(([tap,list])=>{
+        evHTML+=`<h3>${tap}</h3><ul>`;
+        list.forEach(ev=>{
+          evHTML+=`<li>${new Date(ev.time).toLocaleString()} - ${ev.action}${ev.beer? ' ('+ev.beer+')':''} - ${ev.user}</li>`;
+        });
+        evHTML+='</ul>';
+      });
+      evDiv.innerHTML=evHTML;
+    });
+}
+document.getElementById('loadBtn').onclick=load;
+</script>
+</body>
+</html>

--- a/public/taps.html
+++ b/public/taps.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<title>Розлив стоп-пуск</title>
+<style>
+body {font-family: sans-serif; background:#f5f5f5; margin:0;}
+header {padding:1rem; background:#333; color:#fff;}
+a {color:#fff; margin-left:1rem;}
+.container {display:grid; grid-template-columns:repeat(auto-fit,minmax(120px,1fr)); gap:1rem; padding:1rem;}
+.tap {padding:2rem; border-radius:8px; text-align:center; font-size:1.2rem; cursor:pointer; background:#e74c3c; color:#fff;}
+.tap.active {background:#2ecc71;}
+.modal {display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); align-items:center; justify-content:center;}
+.modal-content {background:#fff; padding:1rem; border-radius:8px; width:300px;}
+.modal-content h2 {margin-top:0;}
+.modal-content select, .modal-content input {width:100%; margin-bottom:1rem; padding:0.5rem;}
+.actions button {margin-right:0.5rem; margin-top:0.5rem;}
+</style>
+</head>
+<body>
+<header>
+  <span>Управление кранами</span>
+  <a href="/taps-report.html">Отчёты</a>
+  <a href="/">Главная</a>
+</header>
+<div class="container" id="taps"></div>
+<div class="modal" id="actionModal">
+  <div class="modal-content">
+    <h2 id="modalTitle"></h2>
+    <input type="text" id="user" placeholder="Пользователь">
+    <select id="beerSelect"></select>
+    <div class="actions">
+      <button id="startBtn">ПУСК</button>
+      <button id="stopBtn">СТОП</button>
+      <button id="replaceBtn">ЗАМЕНА</button>
+      <button id="cancelBtn">Отмена</button>
+    </div>
+  </div>
+</div>
+<script>
+const beers = [];
+let currentTap = null;
+function fetchBeers(){
+  return fetch('/api/beers').then(r=>r.json()).then(data=>{
+    beers.splice(0, beers.length, ...data);
+    const sel = document.getElementById('beerSelect');
+    sel.innerHTML = beers.map(b=>`<option value="${b}">${b}</option>`).join('');
+  });
+}
+function fetchTaps(){
+  return fetch('/api/taps').then(r=>r.json()).then(data=>{
+    const cont = document.getElementById('taps');
+    cont.innerHTML='';
+    Object.keys(data).forEach(id=>{
+      const info = data[id];
+      const div = document.createElement('div');
+      div.className = 'tap' + (info.status==='ACTIVE'?' active':'');
+      div.dataset.tap=id;
+      div.textContent = info.status==='ACTIVE'? info.beer : 'СТОП';
+      div.addEventListener('click',()=>openModal(id));
+      cont.appendChild(div);
+    });
+  });
+}
+function openModal(id){
+  currentTap=id;
+  document.getElementById('modalTitle').textContent=id;
+  document.getElementById('actionModal').style.display='flex';
+}
+function closeModal(){
+  document.getElementById('actionModal').style.display='none';
+}
+function sendAction(action){
+  const user=document.getElementById('user').value || 'anon';
+  const beer=document.getElementById('beerSelect').value;
+  const body={action,user};
+  if(action!=='stop') body.beer=beer;
+  fetch('/api/taps/'+currentTap.replace('TAP',''),{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify(body)
+  }).then(r=>r.json()).then(()=>{closeModal();fetchTaps();});
+}
+document.getElementById('startBtn').onclick=()=>sendAction('start');
+document.getElementById('stopBtn').onclick=()=>sendAction('stop');
+document.getElementById('replaceBtn').onclick=()=>sendAction('replace');
+document.getElementById('cancelBtn').onclick=closeModal;
+fetchBeers().then(fetchTaps);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add express endpoints for tap states, events, and history
- create tap control page with 12 tap tiles and modal actions
- add weekly report page with uptime and event history
- link tap status tile on dashboard to new control page

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68c5909068ac8324afa70a44402ca133