### PR TITLE
Link tapStatus tile to taps control page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -472,22 +472,17 @@
                 }
                 
                 html += `
+                    ${metric.id === 'tapStatus' ? '<a href="/taps.html">' : ''}
                     <div class="metric ${metric.size || ''}" data-id="${metric.id}">
                         <h3>${metric.name}</h3>
                         <div class="value">${valueDisplay}</div>
                         ${detailsHTML}
                     </div>
+                    ${metric.id === 'tapStatus' ? '</a>' : ''}
                 `;
             });
 
             dashboard.innerHTML = html;
-
-            const tapTile = dashboard.querySelector('[data-id="tapStatus"]');
-            if (tapTile) {
-                tapTile.addEventListener('click', () => {
-                    window.location.href = '/taps.html';
-                });
-            }
         }
 
         // Функция изменения периода


### PR DESCRIPTION
## Summary
- Wrap the `tapStatus` dashboard tile in a link pointing to `/taps.html` so clicks reliably open the control page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -s -o /tmp/taps.html http://localhost:3000/taps.html && head -n 20 /tmp/taps.html`


------
https://chatgpt.com/codex/tasks/task_e_68c59687857483248ae9b052daee0980